### PR TITLE
Run expr changes

### DIFF
--- a/src_fun/api.h
+++ b/src_fun/api.h
@@ -893,8 +893,8 @@ struct Report
     inline Report& intro(Severity severity, auto at) { return internal_intro(severity, convert(at)); }
     inline Report& continuation(auto at, bool skinny = false) { return internal_continuation(convert(at), skinny); }
     inline Report& snippet(auto at, bool skinny = false, umm before = 2, umm after = 1) { return internal_snippet(convert(at), skinny, before, after); }
-    inline Report& suggestion(String left, auto at, String right, bool skinny = false, umm before = 2, umm after = 1) { return internal_suggestion(left, convert(at), right, skinny, before, after); }
-
+    inline Report& suggestion_insert(String left, auto at, String right, bool skinny = false, umm before = 2, umm after = 1) { return internal_suggestion_insert(left, convert(at), right, skinny, before, after); }
+    inline Report& suggestion_replace(auto at, auto replace_with, bool skinny = false, umm before = 2, umm after = 1) { return internal_suggestion_replace(convert(at), convert(replace_with), skinny, before, after); }
     inline Report& part(auto at, String msg, Severity severity = SEVERITY_ERROR)
     {
         first_part ? intro(severity, at) : continuation(at);
@@ -911,7 +911,8 @@ private:
     Report& internal_intro(Severity severity, Token_Info info);
     Report& internal_continuation(Token_Info info, bool skinny);
     Report& internal_snippet(Token_Info info, bool skinny, umm before, umm after);
-    Report& internal_suggestion(String left, Token_Info info, String right, bool skinny, umm before, umm after);
+    Report& internal_suggestion_insert(String left, Token_Info info, String right, bool skinny, umm before, umm after);
+    Report& internal_suggestion_replace(Token_Info info, Token_Info replace_with, bool skinny, umm before, umm after);
 
     inline Token_Info convert(Token_Info info)        const { return  info;                   }
     inline Token_Info convert(Token_Info const* info) const { return *info;                   }

--- a/src_fun/api.h
+++ b/src_fun/api.h
@@ -895,6 +895,7 @@ struct Report
     inline Report& snippet(auto at, bool skinny = false, umm before = 2, umm after = 1) { return internal_snippet(convert(at), skinny, before, after); }
     inline Report& suggestion_insert(String left, auto at, String right, bool skinny = false, umm before = 2, umm after = 1) { return internal_suggestion_insert(left, convert(at), right, skinny, before, after); }
     inline Report& suggestion_replace(auto at, auto replace_with, bool skinny = false, umm before = 2, umm after = 1) { return internal_suggestion_replace(convert(at), convert(replace_with), skinny, before, after); }
+    inline Report& suggestion_remove(auto at, bool skinny = false, umm before = 2, umm after = 1) { return internal_suggestion_remove(convert(at), skinny, before, after); }
     inline Report& part(auto at, String msg, Severity severity = SEVERITY_ERROR)
     {
         first_part ? intro(severity, at) : continuation(at);
@@ -913,6 +914,7 @@ private:
     Report& internal_snippet(Token_Info info, bool skinny, umm before, umm after);
     Report& internal_suggestion_insert(String left, Token_Info info, String right, bool skinny, umm before, umm after);
     Report& internal_suggestion_replace(Token_Info info, Token_Info replace_with, bool skinny, umm before, umm after);
+    Report& internal_suggestion_remove(Token_Info info, bool skinny, umm before, umm after);
 
     inline Token_Info convert(Token_Info info)        const { return  info;                   }
     inline Token_Info convert(Token_Info const* info) const { return *info;                   }

--- a/src_fun/parser.cpp
+++ b/src_fun/parser.cpp
@@ -614,6 +614,9 @@ static bool parse_expression_leaf(Token_Stream* stream, Block_Builder* builder, 
         if (!take_atom(stream, ATOM_FIRST_IDENTIFIER, "Expected the type alias name after '$'."_s))
             return false;
 
+        if (lookahead_atom(stream, ATOM_COLON, 0))
+            return ReportError(stream->ctx, stream->cursor - 2, "An alias can't have an inferred type because aliases don't have assigned runtime types."_s);
+
         Parsed_Expression* expr = add_expression(builder, EXPRESSION_DECLARATION, start, stream->cursor - 1, out_expression);
         expr->flags |= EXPRESSION_HAS_TO_BE_EXTERNALLY_INFERRED | EXPRESSION_DECLARATION_IS_ALIAS | EXPRESSION_DECLARATION_IS_INFERRED_ALIAS;
         expr->declaration.name  = *name;

--- a/src_fun/report.cpp
+++ b/src_fun/report.cpp
@@ -120,10 +120,10 @@ static String get_severity_label(bool colored, Severity severity)
 }
 
 
-static const String ASCII_HIGHLIGHT_GREEN = "\x1b[32;4;3;1m"_s;
-static const String ASCII_STRIKETHROUGH   = "\x1b[31;9m"_s;
+static const String ANSI_HIGHLIGHT_GREEN = "\x1b[32;4;3;1m"_s;
+static const String ANSI_STRIKETHROUGH   = "\x1b[31;9m"_s;
 
-static String apply_ascii_escape_sequence(Region* region, String string, String escape_sequence)
+static String apply_ansi_escape_sequence(Region* region, String string, String escape_sequence)
 {
     auto split_whitespace = [](String *s, String* out_leading, String* out_trailing)
     {
@@ -241,8 +241,8 @@ Report& Report::internal_suggestion_insert(String left, Token_Info info, String 
 
     if (colored)
     {
-        left  = apply_ascii_escape_sequence(temp, left,  ASCII_HIGHLIGHT_GREEN);
-        right = apply_ascii_escape_sequence(temp, right, ASCII_HIGHLIGHT_GREEN);
+        left  = apply_ansi_escape_sequence(temp, left,  ANSI_HIGHLIGHT_GREEN);
+        right = apply_ansi_escape_sequence(temp, right, ANSI_HIGHLIGHT_GREEN);
     }
 
     String code_before, code_inside, code_after;
@@ -258,7 +258,7 @@ Report& Report::internal_suggestion_replace(Token_Info info, Token_Info replace_
 {
     String replacement = string_from_token_info(ctx, replace_with);
     if (colored)
-        replacement = apply_ascii_escape_sequence(temp, replacement, ASCII_HIGHLIGHT_GREEN);
+        replacement = apply_ansi_escape_sequence(temp, replacement, ANSI_HIGHLIGHT_GREEN);
 
     if (skinny) before = after = 0;
     String source;
@@ -284,7 +284,7 @@ Report& Report::internal_suggestion_remove(Token_Info info, bool skinny, umm bef
     String code_before, code_inside, code_after;
     split_source_around_token_info(&info, source_offset, source, &code_before, &code_inside, &code_after);
 
-    code_inside = apply_ascii_escape_sequence(temp, code_inside, ASCII_STRIKETHROUGH);
+    code_inside = apply_ansi_escape_sequence(temp, code_inside, ANSI_STRIKETHROUGH);
     source = concatenate(temp, code_before, code_inside, code_after);
 
     String file = skinny ? get_file_name(ctx->sources[info.source_index].name) : ""_s;

--- a/src_fun/test/c_backend.fun
+++ b/src_fun/test/c_backend.fun
@@ -4,7 +4,7 @@ using Self     :: import "c_backend.fun";
 using System   :: import "system.fun";
 using Compiler :: import "compiler.fun";
 
-run {
+run unit {
     mem: Region;
 
     Big_Thing1 :: struct {

--- a/src_fun/test/target0.fun
+++ b/src_fun/test/target0.fun
@@ -2,8 +2,7 @@
 // =($a: s64, $b: s64)
 // debug a + b;
 
-run
-{
+run unit {
     using System   :: import "system.fun";
     using Compiler :: import "compiler.fun";
 

--- a/src_fun/test/target1.fun
+++ b/src_fun/test/target1.fun
@@ -1,6 +1,5 @@
 
-run
-{
+run unit {
     debug cast(u64, 12345);
     // "hello world!";
 }


### PR DESCRIPTION
Changes include:
- run expression now takes a unit type as an argument, not a block
- cute error message if you try to pass a block or a value with a runtime unit type
- added `suggestion_replace` in `Report`
- fixed highlighting in `Report::suggestion_*` when you have leading or trailing whitespace
- Fixed error message when trying to infer a type of an alias: `A: $T: Foo;`